### PR TITLE
Move LightDM autologin to grub setup script

### DIFF
--- a/grub-configure.sh
+++ b/grub-configure.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Backup the existing grub configuration
-sudo cp /etc/default/grub /etc/default/grub.backup.$(date +%Y%m%d%H%M%S)
+sudo cp /etc/default/grub "/etc/default/grub.backup.$(date +%Y%m%d%H%M%S)"
 
 echo "Updating GRUB_CMDLINE_LINUX_DEFAULT for LinuxCNC..."
 
@@ -27,6 +27,9 @@ sudo update-initramfs -u
 
 # Update GRUB
 sudo update-grub
+
+# Configure LightDM for autologin
+sudo sed -i '/^\[Seat:\*\]/a autologin-user='"$(whoami)"'\\nautologin-user-timeout=0' /etc/lightdm/lightdm.conf
 
 # Confirmation message
 echo "GRUB and splash screen updated successfully. Please reboot your system."

--- a/i3kiosk.sh
+++ b/i3kiosk.sh
@@ -16,9 +16,6 @@ sudo update-alternatives --set x-session-manager /usr/bin/i3
 # Enable LightDM for graphical login
 sudo systemctl enable lightdm
 
-# Configure LightDM for autologin
-sudo sed -i '/^\[Seat:\*\]/a autologin-user='"$(whoami)"'\nautologin-user-timeout=0' /etc/lightdm/lightdm.conf
-
 # Configure .xsession to start i3 automatically
 echo "exec i3" > ~/.xsession
 chmod +x ~/.xsession


### PR DESCRIPTION
## Summary
- Move LightDM autologin configuration from `i3kiosk.sh` to `grub-configure.sh`
- Quote GRUB backup path to avoid word splitting

## Testing
- `bash -n i3kiosk.sh grub-configure.sh`
- `shellcheck i3kiosk.sh grub-configure.sh`


------
https://chatgpt.com/codex/tasks/task_e_689633b991e8832794a64f3db982dd50