### PR TITLE
Add dev tools and interactive setup scripts

### DIFF
--- a/install-devtools.sh
+++ b/install-devtools.sh
@@ -7,12 +7,21 @@ sudo apt update
 sudo apt install -y git
 
 git config --global user.name "cnc"
-git config --global user.email cnc@cnc.com
+git config --global user.email cnc@cnc.cn
+
+# Generate an SSH key for GitHub if it doesn't already exist and display the public key
+if [ ! -f "$HOME/.ssh/id_ed25519.pub" ]; then
+  ssh-keygen -t ed25519 -C "cnc@cnc.cn" -f "$HOME/.ssh/id_ed25519" -N ""
+fi
+echo "GitHub SSH public key:"
+cat "$HOME/.ssh/id_ed25519.pub"
 
 
 sudo apt install -y mc
 
 sudo apt install -y terminator
+
+sudo apt install -y htop
 
 
 # Enable Syncthing to start automatically on system boot
@@ -30,4 +39,4 @@ sudo apt update
 sudo apt install -y code
 
 # Final message
-echo "Git, and Visual Studio Code installation complete."
+echo "Git, htop, and Visual Studio Code installation complete."

--- a/linuxcnc.sh
+++ b/linuxcnc.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# Create configuration directories
+mkdir -p "$HOME/linuxcnc/configs"
+cd "$HOME/linuxcnc/configs"
+
+# Clone the CorvusCNC repository if it does not already exist
+if [ ! -d "corvuscnc" ]; then
+  git clone git@github.com:ymiroshnychenko668/corvuscnc.git
+else
+  echo "corvuscnc repository already exists."
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -1,22 +1,33 @@
 #!/bin/bash
 
-set -euo pipefail
-IFS=$'\n\t'
+set -e
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SCRIPT_NAME="$(basename "$0")"
+# Collect executable scripts in this directory excluding setup.sh
+shopt -s nullglob
+scripts=()
+for file in *.sh; do
+  [ "$file" = "setup.sh" ] && continue
+  scripts+=("$file")
+done
 
-echo "📁 Running scripts in: $SCRIPT_DIR"
-echo "⚙️  Ignoring: $SCRIPT_NAME"
-echo
+if [ ${#scripts[@]} -eq 0 ]; then
+  echo "No scripts available."
+  exit 0
+fi
 
-for file in "$SCRIPT_DIR"/*.sh; do
-  fname="$(basename "$file")"
-  [[ "$fname" == "$SCRIPT_NAME" ]] && continue
-
-  echo "🚀 Executing $fname..."
-  chmod +x "$file"
-  "$file"
-  echo "✅ Finished $fname"
-  echo
+PS3="Select a script to execute (or choose Quit to exit): "
+select script in "${scripts[@]}" "Quit"; do
+  case $script in
+    "Quit")
+      echo "Exiting."
+      break
+      ;;
+    "")
+      echo "Invalid selection."
+      ;;
+    *)
+      chmod +x "$script"
+      bash "$script"
+      ;;
+  esac
 done


### PR DESCRIPTION
## Summary
- expand dev tools install to configure git identity, generate GitHub SSH key, and install htop
- add linuxcnc.sh to clone CorvusCNC configs into ~/linuxcnc/configs
- rebuild setup.sh with an interactive menu to choose which script to run

## Testing
- `bash -n install-devtools.sh linuxcnc.sh setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_6896fcb649a4832781cfb7f0a0a02da0