### PR TITLE
Print GitHub key info and repeat setup choices

### DIFF
--- a/install-devtools.sh
+++ b/install-devtools.sh
@@ -15,6 +15,7 @@ if [ ! -f "$HOME/.ssh/id_ed25519.pub" ]; then
 fi
 echo "GitHub SSH public key:"
 cat "$HOME/.ssh/id_ed25519.pub"
+echo "Add this key to your GitHub account: https://github.com/settings/keys"
 
 
 sudo apt install -y mc

--- a/setup.sh
+++ b/setup.sh
@@ -16,18 +16,22 @@ if [ ${#scripts[@]} -eq 0 ]; then
 fi
 
 PS3="Select a script to execute (or choose Quit to exit): "
-select script in "${scripts[@]}" "Quit"; do
-  case $script in
-    "Quit")
-      echo "Exiting."
-      break
-      ;;
-    "")
-      echo "Invalid selection."
-      ;;
-    *)
-      chmod +x "$script"
-      bash "$script"
-      ;;
-  esac
+while true; do
+  select script in "${scripts[@]}" "Quit"; do
+    case $script in
+      "Quit")
+        echo "Exiting."
+        exit 0
+        ;;
+      "")
+        echo "Invalid selection."
+        break
+        ;;
+      *)
+        chmod +x "$script"
+        bash "$script"
+        break
+        ;;
+    esac
+  done
 done


### PR DESCRIPTION
## Summary
- Show GitHub SSH public key and link to key settings in dev tools installer
- Re-display available script choices every time setup.sh runs

## Testing
- `bash -n install-devtools.sh setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_6896fea4544c83278e7080c6a385e9d0